### PR TITLE
build: Support build when CGO is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,9 @@ build-arm64:
 	docker build -t sha1cd-arm64 -f Dockerfile.arm64 .
 	docker run --rm sha1cd-arm64
 
+# Build with cgo disabled.
+build-nocgo:
+	CGO_ENABLED=0 go build ./cgo
+
 # Run cross-compilation to assure supported architectures.
-cross-build: build-arm build-arm64
+cross-build: build-arm build-arm64 build-nocgo

--- a/cgo/fallback_no_cgo.go
+++ b/cgo/fallback_no_cgo.go
@@ -1,0 +1,32 @@
+//go:build !cgo
+// +build !cgo
+
+package cgo
+
+import (
+	"hash"
+
+	"github.com/pjbgf/sha1cd"
+	"github.com/pjbgf/sha1cd/ubc"
+)
+
+// CalculateDvMask falls back to github.com/pjbgf/sha1cd/ubc implementation
+// due to CGO being disabled at compilation time.
+func CalculateDvMask(W []uint32) (uint32, error) {
+	return ubc.CalculateDvMask(W)
+}
+
+// CalculateDvMask falls back to github.com/pjbgf/sha1cd implementation
+// due to CGO being disabled at compilation time.
+func New() hash.Hash {
+	return sha1cd.New()
+}
+
+// CalculateDvMask falls back to github.com/pjbgf/sha1cd implementation
+// due to CGO being disabled at compilation time.
+func Sum(data []byte) ([]byte, bool) {
+	d := sha1cd.New().(sha1cd.CollisionResistantHash)
+	d.Write(data)
+
+	return d.CollisionResistantSum(nil)
+}


### PR DESCRIPTION
sha1cd may be a transient dependency to some applications which do not support (or want to) CGO. The changes enable this by falling back to the Pure Go implementation.

If users then want to override the Pure Go sha1cd with the SHA1 implementation from the standard library they can do so with:

`hash.RegisterHash(crypto.SHA1, sha1.New)`