### PR TITLE
C source and header files are not getting downloaded by `go get`

### DIFF
--- a/cgo/sha1.go
+++ b/cgo/sha1.go
@@ -10,7 +10,11 @@ import (
 	"crypto"
 	"hash"
 	"unsafe"
+	"embed"
 )
+
+//go:embed lib/*.h lib/*.c
+var _ embed.FS
 
 const (
 	Size      = 20

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pjbgf/sha1cd
 
-go 1.15
+go 1.19


### PR DESCRIPTION
This was causing the following error (see [https://github.com/go-git/go-git/issues/624](https://github.com/go-git/go-git/issues/624) for more details) when building a project that depends on this library:
```
# github.com/pjbgf/sha1cd/cgo
vendor/github.com/pjbgf/sha1cd/cgo/sha1.go:3:11: fatal error: 'lib/sha1.h' file not found
 #include <lib/sha1.h>
          ^~~~~~~~~~~~
1 error generated.
```
This was as a result of missing `.c` and `.h` files that `go get` omits. I have used the `embed` directive to include these files during the download.