### PR TITLE
Remove `crypto.RegisterHash` call

### DIFF
--- a/cgo/sha1.go
+++ b/cgo/sha1.go
@@ -5,7 +5,6 @@ package cgo
 import "C"
 
 import (
-	"crypto"
 	"hash"
 	"unsafe"
 )
@@ -14,10 +13,6 @@ const (
 	Size      = 20
 	BlockSize = 64
 )
-
-func init() {
-	crypto.RegisterHash(crypto.SHA1, New)
-}
 
 func New() hash.Hash {
 	d := new(digest)

--- a/sha1cd.go
+++ b/sha1cd.go
@@ -12,7 +12,6 @@ package sha1cd
 // Original: https://github.com/golang/go/blob/master/src/crypto/sha1/sha1.go
 
 import (
-	"crypto"
 	"encoding/binary"
 	"errors"
 	"hash"
@@ -21,10 +20,6 @@ import (
 )
 
 //go:generate go run -C asm . -out ../sha1cdblock_amd64.s -pkg $GOPACKAGE
-
-func init() {
-	crypto.RegisterHash(crypto.SHA1, New)
-}
 
 // The size of a SHA-1 checksum in bytes.
 const Size = shared.Size


### PR DESCRIPTION
Remove the crypto registration which replaces the default Go `SHA1` implementation. Users can opt back in that behaviour by calling `crypto.RegisterHash(crypto.SHA1, sha1cd.New)`.