### PR TITLE
build: Add GitHub arm64 runners to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [^1.22.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, ubuntu-24.04-arm]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.21.x, ^1.22.x]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
This will provide a consistent way to test the native `arm64` implementation going forward.