### PR TITLE
Revert "Remove `crypto.RegisterHash` call"

### DIFF
--- a/cgo/sha1.go
+++ b/cgo/sha1.go
@@ -5,6 +5,7 @@ package cgo
 import "C"
 
 import (
+	"crypto"
 	"hash"
 	"unsafe"
 )
@@ -13,6 +14,10 @@ const (
 	Size      = 20
 	BlockSize = 64
 )
+
+func init() {
+	crypto.RegisterHash(crypto.SHA1, New)
+}
 
 func New() hash.Hash {
 	d := new(digest)

--- a/sha1cd.go
+++ b/sha1cd.go
@@ -12,6 +12,7 @@ package sha1cd
 // Original: https://github.com/golang/go/blob/master/src/crypto/sha1/sha1.go
 
 import (
+	"crypto"
 	"encoding/binary"
 	"errors"
 	"hash"
@@ -20,6 +21,10 @@ import (
 )
 
 //go:generate go run -C asm . -out ../sha1cdblock_amd64.s -pkg $GOPACKAGE
+
+func init() {
+	crypto.RegisterHash(crypto.SHA1, New)
+}
 
 // The size of a SHA-1 checksum in bytes.
 const Size = shared.Size


### PR DESCRIPTION
Reverts pjbgf/sha1cd#170.

This change was initially intended to enable a different opt-in approach by `go-git/go-git/v6`, which in the end was discarded.