### PR TITLE
build: Decrease dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: semiannually
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: weekly
+      interval: semiannually
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
This project has no external dependencies for its code logic. For testing and CI it has only dependencies to the Golang container image, and to some GH actions built by GitHub.

Due to this the interval in which such testing dependencies are being bumped is being decreased to semiannually, so that the noise in PRs is decreased.