### PR TITLE
Introduce SIMD for arm64

### DIFF
--- a/cgo/sha1.go
+++ b/cgo/sha1.go
@@ -20,9 +20,9 @@ func init() {
 }
 
 func New() hash.Hash {
-	d := new(digest)
+	var d digest
 	d.Reset()
-	return d
+	return &d
 }
 
 type digest struct {
@@ -60,7 +60,8 @@ func (d *digest) Size() int { return Size }
 func (d *digest) BlockSize() int { return BlockSize }
 
 func Sum(data []byte) ([]byte, bool) {
-	d := New().(*digest)
+	var d digest
+	d.Reset()
 	d.Write(data)
 
 	h, c := d.sum()

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/pjbgf/sha1cd
 
-go 1.21
+go 1.22
+
+toolchain go1.24.6
+
+// Temporary dependency to be removed once CPU feature checks
+// are natively supported. https://github.com/golang/go/issues/73787
+require github.com/klauspost/cpuid/v2 v2.3.0
+
+require golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
+github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/sha1cd.go
+++ b/sha1cd.go
@@ -20,8 +20,6 @@ import (
 	shared "github.com/pjbgf/sha1cd/internal"
 )
 
-//go:generate go run -C asm . -out ../sha1cdblock_amd64.s -pkg $GOPACKAGE
-
 func init() {
 	crypto.RegisterHash(crypto.SHA1, New)
 }

--- a/sha1cdblock_amd64.go
+++ b/sha1cdblock_amd64.go
@@ -23,13 +23,13 @@ func block(dig *digest, p []byte) {
 	cs := [shared.PreStepState][shared.WordBuffers]uint32{}
 
 	for len(p) >= shared.Chunk {
-		// Only send a block to be processed, as the collission detection
-		// works on a block by block basis.
+		// The assembly code only supports processing a block at a time,
+		// so adjust the chunk accordingly.
 		chunk := p[:shared.Chunk]
 
 		blockAMD64(dig.h[:], chunk, m1[:], cs[:])
 
-		col := checkCollision(m1, cs, dig.h[:])
+		col := checkCollision(m1, cs, dig.h)
 		if col {
 			dig.col = true
 

--- a/sha1cdblock_arm64.go
+++ b/sha1cdblock_arm64.go
@@ -4,8 +4,13 @@
 package sha1cd
 
 import (
+	"runtime"
+
+	"github.com/klauspost/cpuid/v2"
 	shared "github.com/pjbgf/sha1cd/internal"
 )
+
+var hasSHA1 = (runtime.GOARCH == "arm64" && cpuid.CPU.Supports(cpuid.SHA1))
 
 // blockARM64 hashes the message p into the current state in h.
 // Both m1 and cs are used to store intermediate results which are used by the collision detection logic.
@@ -14,7 +19,7 @@ import (
 func blockARM64(h []uint32, p []byte, m1 []uint32, cs [][5]uint32)
 
 func block(dig *digest, p []byte) {
-	if forceGeneric {
+	if forceGeneric || !hasSHA1 {
 		blockGeneric(dig, p)
 		return
 	}
@@ -23,13 +28,14 @@ func block(dig *digest, p []byte) {
 	cs := [shared.PreStepState][shared.WordBuffers]uint32{}
 
 	for len(p) >= shared.Chunk {
-		// Only send a block to be processed, as the collission detection
-		// works on a block by block basis.
+		// The assembly code only supports processing a block at a time,
+		// so adjust the chunk accordingly.
 		chunk := p[:shared.Chunk]
 
 		blockARM64(dig.h[:], chunk, m1[:], cs[:])
 
-		col := checkCollision(m1, cs, dig.h[:])
+		rectifyCompressionState(m1, &cs)
+		col := checkCollision(m1, cs, dig.h)
 		if col {
 			dig.col = true
 

--- a/sha1cdblock_arm64.s
+++ b/sha1cdblock_arm64.s
@@ -2,243 +2,242 @@
 
 #include "textflag.h"
 
-#define RoundConst0 $1518500249 // 0x5A827999
-#define RoundConst1 $1859775393 // 0x6ED9EBA1
-#define RoundConst2 $2400959708 // 0x8F1BBCDC
-#define RoundConst3 $3395469782 // 0xCA62C1D6
+// Reference implementations:
+// https://github.com/noloader/SHA-Intrinsics/blob/master/sha1-arm.c
+// https://github.com/golang/go/blob/master/src/crypto/sha1/sha1block_arm64.s
 
-// FUNC1 f = (b & c) | ((~b) & d)
-#define FUNC1(b, c, d) \
-	MOVW d, R15; \
-	EORW c, R15; \
-	ANDW b, R15; \
-	EORW d, R15
+#define HASHUPDATECHOOSE \
+	SHA1C	V16.S4, V1, V2 \
+	SHA1H	V3, V1 \
+	VMOV	V2.B16, V3.B16
 
-// FUNC2 f = b ^ c ^ d
-#define FUNC2(b, c, d) \
-	MOVW b, R15; \
-	EORW c, R15; \
-	EORW d, R15
+#define HASHUPDATEPARITY \
+	SHA1P	V16.S4, V1, V2 \
+	SHA1H	V3, V1 \
+	VMOV	V2.B16, V3.B16
 
-// FUNC3 f = (b & c) | (b & d) | (c & d)
-#define FUNC3(b, c, d) \
-	MOVW b, R27; \
-	ORR c, R27, R27; \
-	ANDW d, R27, R27; \
-	MOVW b, R15; \
-	ANDW c, R15, R15; \
-	ORR R27, R15, R15
-
-#define FUNC4(b, c, d) FUNC2(b, c, d)
-	
-#define MIX(a, b, c, d, e, k) \
-	RORW $2, b, b; \
-	ADDW R15, e, e; \
-	MOVW a, R27; \
-	RORW $27, R27, R27; \
-	MOVW k, R19; \
-	ADDW R19, e, e; \
-	ADDW R9, e, e; \
-	ADDW R27, e, e
-
-#define LOAD(index) \
-	MOVWU (index*4)(R16), R9; \
-	REVW R9, R9; \
-	MOVW R9, (index*4)(RSP)
-
-#define LOADCS(a, b, c, d, e, index) \
-	MOVD cs_base+72(FP), R27; \
-	MOVW a, ((index*20))(R27); \
-	MOVW b, ((index*20)+4)(R27); \
-	MOVW c, ((index*20)+8)(R27); \
-	MOVW d, ((index*20)+12)(R27); \
-	MOVW e, ((index*20)+16)(R27)
-
-#define SHUFFLE(index) \
-	MOVW ((index&0xf)*4)(RSP), R9; \
-	MOVW (((index-3)&0xf)*4)(RSP), R20; \
-	EORW R20, R9; \
-	MOVW (((index-8)&0xf)*4)(RSP), R20; \
-	EORW R20, R9; \
-	MOVW (((index-14)&0xf)*4)(RSP), R20; \
-	EORW R20, R9; \
-	RORW $31, R9, R9; \
-	MOVW R9, ((index&0xf)*4)(RSP)
-
-// LOADM1 stores message word to m1 array.
-#define LOADM1(index) \
-	MOVD m1_base+48(FP), R27; \
-	MOVW ((index&0xf)*4)(RSP), R9; \
-	MOVW R9, (index*4)(R27)
-
-#define ROUND1(a, b, c, d, e, index) \
-	LOAD(index); \
-	FUNC1(b, c, d); \
-	MIX(a, b, c, d, e, RoundConst0); \
-	LOADM1(index)
-
-#define ROUND1x(a, b, c, d, e, index) \
-	SHUFFLE(index); \
-	FUNC1(b, c, d); \
-	MIX(a, b, c, d, e, RoundConst0); \
-	LOADM1(index)
-
-#define ROUND2(a, b, c, d, e, index) \
-	SHUFFLE(index); \
-	FUNC2(b, c, d); \
-	MIX(a, b, c, d, e, RoundConst1); \
-	LOADM1(index)
-
-#define ROUND3(a, b, c, d, e, index) \
-	SHUFFLE(index); \
-	FUNC3(b, c, d); \
-	MIX(a, b, c, d, e, RoundConst2); \
-	LOADM1(index)
-
-#define ROUND4(a, b, c, d, e, index) \
-	SHUFFLE(index); \
-	FUNC4(b, c, d); \
-	MIX(a, b, c, d, e, RoundConst3); \
-	LOADM1(index)
+#define HASHUPDATEMAJ \
+	SHA1M	V16.S4, V1, V2 \
+	SHA1H	V3, V1 \
+	VMOV	V2.B16, V3.B16
 
 // func blockARM64(h []uint32, p []byte, m1 []uint32, cs [][5]uint32)
 TEXT ·blockARM64(SB), NOSPLIT, $80-96
-    MOVD    h_base+0(FP), R8
-    MOVD    p_base+24(FP), R16
-    MOVD    p_len+32(FP), R10
+	MOVD	h_base+0(FP), R0
+	MOVD	p_base+24(FP), R1
+	MOVD	p_len+32(FP), R2
+	MOVD	m1_base+48(FP), R3
+	MOVD	cs_base+72(FP), R4
 
-    LSR     $6, R10, R10
-    LSL     $6, R10, R10
-    ADD     R16, R10, R21
+    LSR     $6, R2, R2
+    LSL     $6, R2, R2
+    ADD     R16, R2, R21
 
-    // Load h0-h4 into R1–R5.
-    MOVW    (R8), R1                   // R1 = h0
-    MOVW    4(R8), R2                  // R2 = h1
-    MOVW    8(R8), R3                  // R3 = h2
-    MOVW    12(R8), R4                 // R4 = h3
-    MOVW    16(R8), R5                 // R5 = h4
+	VLD1.P	16(R0), [V0.S4]
+	FMOVS	(R0), F20
+	SUB	$16, R0, R0
 
 loop:
-    // len(p) >= chunk
-    CMP     R16, R21
-    BLS     end
+	CMP     R16, R21
+	BLS     end
 
-	// Initialize registers a, b, c, d, e.
-	MOVW R1, R10
-	MOVW R2, R11
-	MOVW R3, R12
-	MOVW R4, R13
-	MOVW R5, R14
+	// Load block (p) into 16-bytes vectors.
+	VLD1.P	16(R1), [V4.B16]
+	VLD1.P	16(R1), [V5.B16]
+	VLD1.P	16(R1), [V6.B16]
+	VLD1.P	16(R1), [V7.B16]
+	
+	// Load K constants to V19
+	MOVD  $·sha1Ks(SB), R22
+	VLD1  (R22), [V19.S4]
+                              
+	VMOV	V0.B16, V2.B16
+	VMOV	V20.S[0], V1
+	VMOV	V2.B16, V3.B16
+	VDUP	V19.S[0], V17.S4
+	
+	// Little Endian
+	VREV32	V4.B16, V4.B16
+	VREV32	V5.B16, V5.B16
+	VREV32	V6.B16, V6.B16
+	VREV32	V7.B16, V7.B16
+	
+	// LOAD M1 rounds 0-15
+	VST1.P    [V4.S4], (R3)
+	VST1.P    [V5.S4], (R3)
+	VST1.P    [V6.S4], (R3)
+	VST1.P    [V7.S4], (R3)
 
-	// ROUND1 (steps 0-15)
-	LOADCS(R10, R11, R12, R13, R14, 0)
-	ROUND1(R10, R11, R12, R13, R14, 0)
-	ROUND1(R14, R10, R11, R12, R13, 1)
-	ROUND1(R13, R14, R10, R11, R12, 2)
-	ROUND1(R12, R13, R14, R10, R11, 3)
-	ROUND1(R11, R12, R13, R14, R10, 4)
-	ROUND1(R10, R11, R12, R13, R14, 5)
-	ROUND1(R14, R10, R11, R12, R13, 6)
-	ROUND1(R13, R14, R10, R11, R12, 7)
-	ROUND1(R12, R13, R14, R10, R11, 8)
-	ROUND1(R11, R12, R13, R14, R10, 9)
-	ROUND1(R10, R11, R12, R13, R14, 10)
-	ROUND1(R14, R10, R11, R12, R13, 11)
-	ROUND1(R13, R14, R10, R11, R12, 12)
-	ROUND1(R12, R13, R14, R10, R11, 13)
-	ROUND1(R11, R12, R13, R14, R10, 14)
-	ROUND1(R10, R11, R12, R13, R14, 15)
+	// LOAD CS 0
+    VST1.P    [V0.S4], (R4)  // ABCD pre-round 0
+	VST1.P    V1.S[0], 4(R4) // E pre-round 0
 
-	// ROUND1x (steps 16-19) - same as ROUND1 but with no data load.
-	ROUND1x(R14, R10, R11, R12, R13, 16)
-	ROUND1x(R13, R14, R10, R11, R12, 17)
-	ROUND1x(R12, R13, R14, R10, R11, 18)
-	ROUND1x(R11, R12, R13, R14, R10, 19)
+	// Rounds 0-3
+	VDUP	V19.S[1], V18.S4
+	VADD	V17.S4, V4.S4, V16.S4
+	SHA1SU0	V6.S4, V5.S4, V4.S4
+	HASHUPDATECHOOSE
+	SHA1SU1	V7.S4, V4.S4
 
-	// ROUND2 (steps 20-39)
-	ROUND2(R10, R11, R12, R13, R14, 20)
-	ROUND2(R14, R10, R11, R12, R13, 21)
-	ROUND2(R13, R14, R10, R11, R12, 22)
-	ROUND2(R12, R13, R14, R10, R11, 23)
-	ROUND2(R11, R12, R13, R14, R10, 24)
-	ROUND2(R10, R11, R12, R13, R14, 25)
-	ROUND2(R14, R10, R11, R12, R13, 26)
-	ROUND2(R13, R14, R10, R11, R12, 27)
-	ROUND2(R12, R13, R14, R10, R11, 28)
-	ROUND2(R11, R12, R13, R14, R10, 29)
-	ROUND2(R10, R11, R12, R13, R14, 30)
-	ROUND2(R14, R10, R11, R12, R13, 31)
-	ROUND2(R13, R14, R10, R11, R12, 32)
-	ROUND2(R12, R13, R14, R10, R11, 33)
-	ROUND2(R11, R12, R13, R14, R10, 34)
-	ROUND2(R10, R11, R12, R13, R14, 35)
-	ROUND2(R14, R10, R11, R12, R13, 36)
-	ROUND2(R13, R14, R10, R11, R12, 37)
-	ROUND2(R12, R13, R14, R10, R11, 38)
-	ROUND2(R11, R12, R13, R14, R10, 39)
+	// Rounds 4-7
+	VADD	V17.S4, V5.S4, V16.S4
+	SHA1SU0	V7.S4, V6.S4, V5.S4
+	HASHUPDATECHOOSE
+	SHA1SU1	V4.S4, V5.S4
+	// LOAD M1 rounds 16-19
+	VST1.P    [V4.S4], (R3)
 
-	// ROUND3 (steps 40-59)
-	ROUND3(R10, R11, R12, R13, R14, 40)
-	ROUND3(R14, R10, R11, R12, R13, 41)
-	ROUND3(R13, R14, R10, R11, R12, 42)
-	ROUND3(R12, R13, R14, R10, R11, 43)
-	ROUND3(R11, R12, R13, R14, R10, 44)
-	ROUND3(R10, R11, R12, R13, R14, 45)
-	ROUND3(R14, R10, R11, R12, R13, 46)
-	ROUND3(R13, R14, R10, R11, R12, 47)
-	ROUND3(R12, R13, R14, R10, R11, 48)
-	ROUND3(R11, R12, R13, R14, R10, 49)
-	ROUND3(R10, R11, R12, R13, R14, 50)
-	ROUND3(R14, R10, R11, R12, R13, 51)
-	ROUND3(R13, R14, R10, R11, R12, 52)
-	ROUND3(R12, R13, R14, R10, R11, 53)
-	ROUND3(R11, R12, R13, R14, R10, 54)
-	ROUND3(R10, R11, R12, R13, R14, 55)
-	ROUND3(R14, R10, R11, R12, R13, 56)
-	ROUND3(R13, R14, R10, R11, R12, 57)
+	// Rounds 8-11
+	VADD	V17.S4, V6.S4, V16.S4
+	SHA1SU0	V4.S4, V7.S4, V6.S4
+	HASHUPDATECHOOSE
+	SHA1SU1	V5.S4, V6.S4
+	// LOAD M1 rounds 20-23
+	VST1.P    [V5.S4], (R3)
 
-	LOADCS(R12, R13, R14, R10, R11, 1)
-	ROUND3(R12, R13, R14, R10, R11, 58)
-	ROUND3(R11, R12, R13, R14, R10, 59)
+	// Rounds 12-15
+	VADD	V17.S4, V7.S4, V16.S4
+	SHA1SU0	V5.S4, V4.S4, V7.S4
+	HASHUPDATECHOOSE
+	SHA1SU1	V6.S4, V7.S4
+	// LOAD M1 rounds 24-27
+	VST1.P    [V6.S4], (R3)
 
-	// ROUND4 (steps 60-79)
-	ROUND4(R10, R11, R12, R13, R14, 60)
-	ROUND4(R14, R10, R11, R12, R13, 61)
-	ROUND4(R13, R14, R10, R11, R12, 62)
-	ROUND4(R12, R13, R14, R10, R11, 63)
-	ROUND4(R11, R12, R13, R14, R10, 64)
+	// Rounds 16-19
+	VADD	V17.S4, V4.S4, V16.S4
+	SHA1SU0	V6.S4, V5.S4, V4.S4
+	HASHUPDATECHOOSE
+	SHA1SU1	V7.S4, V4.S4
+	// LOAD M1 rounds 28-31
+	VST1.P    [V7.S4], (R3)
 
-	LOADCS(R10, R11, R12, R13, R14, 2)
-	ROUND4(R10, R11, R12, R13, R14, 65)
-	ROUND4(R14, R10, R11, R12, R13, 66)
-	ROUND4(R13, R14, R10, R11, R12, 67)
-	ROUND4(R12, R13, R14, R10, R11, 68)
-	ROUND4(R11, R12, R13, R14, R10, 69)
-	ROUND4(R10, R11, R12, R13, R14, 70)
-	ROUND4(R14, R10, R11, R12, R13, 71)
-	ROUND4(R13, R14, R10, R11, R12, 72)
-	ROUND4(R12, R13, R14, R10, R11, 73)
-	ROUND4(R11, R12, R13, R14, R10, 74)
-	ROUND4(R10, R11, R12, R13, R14, 75)
-	ROUND4(R14, R10, R11, R12, R13, 76)
-	ROUND4(R13, R14, R10, R11, R12, 77)
-	ROUND4(R12, R13, R14, R10, R11, 78)
-	ROUND4(R11, R12, R13, R14, R10, 79)
+	// Rounds 20-23
+	VDUP	V19.S[2], V17.S4
+	VADD	V18.S4, V5.S4, V16.S4
+	SHA1SU0	V7.S4, V6.S4, V5.S4
+	HASHUPDATEPARITY
+	SHA1SU1	V4.S4, V5.S4
+	// LOAD M1 rounds 32-35
+	VST1.P    [V4.S4], (R3)
 
-	// Add registers to temp hash.
-	ADDW R10, R1, R1
-	ADDW R11, R2, R2
-	ADDW R12, R3, R3
-	ADDW R13, R4, R4
-	ADDW R14, R5, R5
+	// Rounds 24-27
+	VADD	V18.S4, V6.S4, V16.S4
+	SHA1SU0	V4.S4, V7.S4, V6.S4
+	HASHUPDATEPARITY
+	SHA1SU1	V5.S4, V6.S4
+	// LOAD M1 rounds 36-39
+	VST1.P    [V5.S4], (R3)
 
-	ADD  $64, R16, R16
-	B  loop
+	// Rounds 28-31
+	VADD	V18.S4, V7.S4, V16.S4
+	SHA1SU0	V5.S4, V4.S4, V7.S4
+	HASHUPDATEPARITY
+	SHA1SU1	V6.S4, V7.S4
+	// LOAD M1 rounds 40-43
+	VST1.P    [V6.S4], (R3)
+
+	// Rounds 32-35
+	VADD	V18.S4, V4.S4, V16.S4
+	SHA1SU0	V6.S4, V5.S4, V4.S4
+	HASHUPDATEPARITY
+	SHA1SU1	V7.S4, V4.S4
+	// LOAD M1 rounds 44-47
+	VST1.P    [V7.S4], (R3)
+
+	// Rounds 36-39
+	VADD	V18.S4, V5.S4, V16.S4
+	SHA1SU0	V7.S4, V6.S4, V5.S4
+	HASHUPDATEPARITY
+	SHA1SU1	V4.S4, V5.S4
+	// LOAD M1 rounds 48-51
+	VST1.P    [V4.S4], (R3)
+
+	// Rounds 44-47
+	VDUP	V19.S[3], V18.S4
+	VADD	V17.S4, V6.S4, V16.S4
+	SHA1SU0	V4.S4, V7.S4, V6.S4
+	HASHUPDATEMAJ
+	SHA1SU1	V5.S4, V6.S4
+	// LOAD M1 rounds 52-55
+	VST1.P    [V5.S4], (R3)
+
+	// Rounds 44-47
+	VADD	V17.S4, V7.S4, V16.S4
+	SHA1SU0	V5.S4, V4.S4, V7.S4
+	HASHUPDATEMAJ
+	SHA1SU1	V6.S4, V7.S4
+	// LOAD M1 rounds 56-59
+	VST1.P    [V6.S4], (R3)
+
+	// Rounds 48-51
+	VADD	V17.S4, V4.S4, V16.S4
+	SHA1SU0	V6.S4, V5.S4, V4.S4
+	HASHUPDATEMAJ
+	SHA1SU1	V7.S4, V4.S4
+	// LOAD M1 rounds 60-63
+	VST1.P    [V7.S4], (R3)
+	
+	// Rounds 52-55
+	VADD	V17.S4, V5.S4, V16.S4
+	SHA1SU0	V7.S4, V6.S4, V5.S4
+	HASHUPDATEMAJ
+	SHA1SU1	V4.S4, V5.S4
+
+	// LOAD CS 58
+    VST1.P    [V3.S4], (R4)  // ABCD pre-round 56
+	VST1.P    V1.S[0], 4(R4) // E pre-round 56
+
+	// Rounds 56-59
+	VADD	V17.S4, V6.S4, V16.S4
+	SHA1SU0	V4.S4, V7.S4, V6.S4
+	HASHUPDATEMAJ
+	SHA1SU1	V5.S4, V6.S4
+
+	// Rounds 60-63
+	VADD	V18.S4, V7.S4, V16.S4
+	SHA1SU0	V5.S4, V4.S4, V7.S4
+	HASHUPDATEPARITY
+	SHA1SU1	V6.S4, V7.S4
+
+	// LOAD CS 65
+    VST1.P    [V3.S4], (R4)  // ABCD pre-round 64
+	VST1.P    V1.S[0], 4(R4) // E pre-round 64
+
+	// Rounds 64-67
+	VADD	V18.S4, V4.S4, V16.S4
+	HASHUPDATEPARITY
+
+	// LOAD M1 rounds 68-79
+	VST1.P    [V4.S4], (R3)
+	VST1.P    [V5.S4], (R3)
+	VST1.P    [V6.S4], (R3)
+	VST1.P    [V7.S4], (R3)
+
+	// Rounds 68-71
+	VADD	V18.S4, V5.S4, V16.S4
+	HASHUPDATEPARITY
+
+	// Rounds 72-75
+	VADD	V18.S4, V6.S4, V16.S4
+	HASHUPDATEPARITY
+
+	// Rounds 76-79
+	VADD	V18.S4, V7.S4, V16.S4
+	HASHUPDATEPARITY
+
+	// Add working registers to hash state.
+	VADD	V2.S4, V0.S4, V0.S4
+	VADD	V1.S4, V20.S4, V20.S4
 
 end:
-	MOVW R1, (R8)
-	MOVW R2, 4(R8)
-	MOVW R3, 8(R8)
-	MOVW R4, 12(R8)
-	MOVW R5, 16(R8)
+	// Update h with final hash values.
+	VST1.P	[V0.S4], (R0)
+	FMOVS	F20, (R0)
+	
 	RET
+
+DATA ·sha1Ks+0(SB)/4,  $0x5A827999 // K0
+DATA ·sha1Ks+4(SB)/4,  $0x6ED9EBA1 // K1
+DATA ·sha1Ks+8(SB)/4,  $0x8F1BBCDC // K2
+DATA ·sha1Ks+12(SB)/4, $0xCA62C1D6 // K3
+GLOBL ·sha1Ks(SB), RODATA, $16

--- a/ubc/ubc.go
+++ b/ubc/ubc.go
@@ -1,5 +1,3 @@
 // ubc package provides ways for SHA1 blocks to be checked for
 // Unavoidable Bit Conditions that arise from crypto analysis attacks.
 package ubc
-
-//go:generate go run -C asm . -out ../ubc_amd64.s -pkg $GOPACKAGE

--- a/ubc/ubc_amd64.go
+++ b/ubc/ubc_amd64.go
@@ -3,12 +3,10 @@
 
 package ubc
 
+//go:noescape
 func CalculateDvMaskAMD64(W [80]uint32) uint32
 
-// Check takes as input an expanded message block and verifies the unavoidable bitconditions
-// for all listed DVs. It returns a dvmask where each bit belonging to a DV is set if all
-// unavoidable bitconditions for that DV have been met.
-// Thus, one needs to do the recompression check for each DV that has its bit set.
+//go:nosplit
 func CalculateDvMask(W [80]uint32) uint32 {
 	return CalculateDvMaskAMD64(W)
 }

--- a/ubc/ubc_arm64.go
+++ b/ubc/ubc_arm64.go
@@ -3,11 +3,10 @@
 
 package ubc
 
+//go:noescape
 func CalculateDvMaskARM64(W [80]uint32) uint32
 
-// Check takes as input an expanded message block and verifies the unavoidable
-// bitconditions for all listed DVs. It returns a dvmask where each bit belonging
-// to a DV is set if all unavoidable bitconditions for that DV have been met.
+//go:nosplit
 func CalculateDvMask(W [80]uint32) uint32 {
 	return CalculateDvMaskARM64(W)
 }

--- a/ubc/ubc_generic.go
+++ b/ubc/ubc_generic.go
@@ -21,10 +21,12 @@ type DvInfo struct {
 	Dm [80]uint32
 }
 
-// CalculateDvMask takes as input an expanded message block and verifies the unavoidable bitconditions
-// for all listed DVs. It returns a dvmask where each bit belonging to a DV is set if all
-// unavoidable bitconditions for that DV have been met.
-// Thus, one needs to do the recompression check for each DV that has its bit set.
+// CalculateDvMaskGeneric takes as input an expanded message block and
+// verifies the unavoidable bitconditions for all listed DVs. It returns
+// a dvmask where each bit belonging to a DV is set if all unavoidable
+// bitconditions for that DV have been met.
+//
+//go:nosplit
 func CalculateDvMaskGeneric(W [80]uint32) uint32 {
 	mask := uint32(0xFFFFFFFF)
 	mask &= (((((W[44] ^ W[45]) >> 29) & 1) - 1) | ^(DV_I_48_0_bit | DV_I_51_0_bit | DV_I_52_0_bit | DV_II_45_0_bit | DV_II_46_0_bit | DV_II_50_0_bit | DV_II_51_0_bit))
@@ -363,6 +365,7 @@ func not(x uint32) uint32 {
 	return 0
 }
 
+//go:nosplit
 func SHA1_dvs() []DvInfo {
 	return sha1_dvs
 }

--- a/ubc/ubc_noasm.go
+++ b/ubc/ubc_noasm.go
@@ -3,10 +3,12 @@
 
 package ubc
 
-// Check takes as input an expanded message block and verifies the unavoidable bitconditions
-// for all listed DVs. It returns a dvmask where each bit belonging to a DV is set if all
-// unavoidable bitconditions for that DV have been met.
-// Thus, one needs to do the recompression check for each DV that has its bit set.
+// CalculateDvMask takes as input an expanded message block and
+// verifies the unavoidable bitconditions for all listed DVs. It returns
+// a dvmask where each bit belonging to a DV is set if all unavoidable
+// bitconditions for that DV have been met.
+//
+//go:nosplit
 func CalculateDvMask(W [80]uint32) uint32 {
 	return CalculateDvMaskGeneric(W)
 }


### PR DESCRIPTION
Introduces a SIMD implementation for the arm64 architecture that is largely based on ARM64 SHA1 and aligns with upstream Go. Extensive comments were added to make it easier to maintain the code going forwards.

The previous non-SIMD implementation was removed, as the SHA1 feature is fairly well supported across modern ARM64 hardware. Keeping both versions in place is not worth the additional complexity.

The check for SHA1 feature is based on github.com/klauspost/cpuid/v2. This is a temporary dependency which will be removed once Go exports the same functionality.

The new arm64 native implementation is ~30% faster and can process ~50% more data, **performing better than the cgo alternative**:
```
pkg: github.com/pjbgf/sha1cd/test
                                   │     /tmp/before     │                 /tmp/after                 │
                                   │       sec/op        │       sec/op         vs base                │
CalculateDvMask/generic-2            0.0000005500n ± 64%   0.0000009000n ± 22%  +63.64% (p=0.003 n=10)
CalculateDvMask/native-2             0.0000008500n ± 18%   0.0000009000n ± 22%        ~ (p=1.000 n=10)
CalculateDvMask/cgo-2                 0.000001950n ± 28%    0.000002200n ± 73%        ~ (p=0.170 n=10)
Hash8Bytes/sha1-2                           105.8n ±  5%          105.2n ±  0%   -0.57% (p=0.002 n=10)
Hash8Bytes/sha1cd_native-2                  426.4n ±  0%          298.0n ±  0%  -30.12% (p=0.000 n=10)
Hash8Bytes/sha1cd_generic-2                 539.0n ±  1%          538.5n ±  1%        ~ (p=0.171 n=10)
Hash8Bytes/sha1cd_cgo-2                     1.671µ ±  3%          1.677µ ±  8%        ~ (p=0.955 n=10)
Hash320Bytes/sha1-2                         317.4n ±  1%          318.0n ±  0%        ~ (p=0.323 n=10)
Hash320Bytes/sha1cd_native-2                2.257µ ±  0%          1.483µ ±  1%  -34.29% (p=0.000 n=10)
Hash320Bytes/sha1cd_generic-2               2.938µ ±  1%          2.943µ ±  1%        ~ (p=0.238 n=10)
Hash320Bytes/sha1cd_cgo-2                   3.103µ ±  2%          3.038µ ±  2%   -2.10% (p=0.009 n=10)
Hash1K/sha1-2                               786.1n ±  1%          785.8n ±  1%        ~ (p=1.000 n=10)
Hash1K/sha1cd_native-2                      6.255µ ±  1%          4.033µ ±  0%  -35.53% (p=0.000 n=10)
Hash1K/sha1cd_generic-2                     8.194µ ±  1%          8.218µ ±  0%        ~ (p=0.119 n=10)
Hash1K/sha1cd_cgo-2                         5.856µ ±  1%          5.809µ ±  2%        ~ (p=0.089 n=10)
Hash8K/sha1-2                               5.744µ ±  1%          5.764µ ±  1%        ~ (p=0.739 n=10)
Hash8K/sha1cd_native-2                      48.23µ ±  1%          31.41µ ±  1%  -34.88% (p=0.000 n=10)
Hash8K/sha1cd_generic-2                     63.07µ ±  1%          63.05µ ±  0%        ~ (p=0.481 n=10)
Hash8K/sha1cd_cgo-2                         34.55µ ±  2%          33.83µ ±  3%        ~ (p=0.105 n=10)
HashWithCollision/sha1cd_native-2           7.518µ ±  1%          6.115µ ±  0%  -18.66% (p=0.000 n=10)
HashWithCollision/sha1cd_generic-2          8.793µ ±  1%          8.782µ ±  0%        ~ (p=0.171 n=10)
HashWithCollision/sha1cd_cgo-2              6.591µ ±  1%          6.467µ ±  1%   -1.87% (p=0.004 n=10)
geomean                                     171.9n                162.4n         -5.51%

                                   │ /tmp/before  │              /tmp/after              │
                                   │     B/s      │      B/s       vs base                │
Hash8Bytes/sha1-2                    72.13Mi ± 5%    72.54Mi ± 0%   +0.56% (p=0.001 n=10)
Hash8Bytes/sha1cd_native-2           17.89Mi ± 0%    25.60Mi ± 0%  +43.10% (p=0.000 n=10)
Hash8Bytes/sha1cd_generic-2          14.15Mi ± 1%    14.17Mi ± 1%        ~ (p=0.202 n=10)
Hash8Bytes/sha1cd_cgo-2              4.568Mi ± 3%    4.554Mi ± 8%        ~ (p=0.926 n=10)
Hash320Bytes/sha1-2                  961.3Mi ± 1%    959.6Mi ± 0%        ~ (p=0.247 n=10)
Hash320Bytes/sha1cd_native-2         135.2Mi ± 0%    205.8Mi ± 1%  +52.23% (p=0.000 n=10)
Hash320Bytes/sha1cd_generic-2        103.8Mi ± 1%    103.7Mi ± 1%        ~ (p=0.255 n=10)
Hash320Bytes/sha1cd_cgo-2            98.35Mi ± 2%   100.46Mi ± 2%   +2.15% (p=0.010 n=10)
Hash1K/sha1-2                        1.213Gi ± 1%    1.214Gi ± 1%        ~ (p=1.000 n=10)
Hash1K/sha1cd_native-2               156.1Mi ± 1%    242.2Mi ± 0%  +55.12% (p=0.000 n=10)
Hash1K/sha1cd_generic-2              119.2Mi ± 1%    118.8Mi ± 0%        ~ (p=0.117 n=10)
Hash1K/sha1cd_cgo-2                  166.8Mi ± 1%    168.1Mi ± 2%        ~ (p=0.089 n=10)
Hash8K/sha1-2                        1.328Gi ± 1%    1.324Gi ± 1%        ~ (p=0.739 n=10)
Hash8K/sha1cd_native-2               162.0Mi ± 1%    248.8Mi ± 1%  +53.56% (p=0.000 n=10)
Hash8K/sha1cd_generic-2              123.9Mi ± 1%    123.9Mi ± 0%        ~ (p=0.481 n=10)
Hash8K/sha1cd_cgo-2                  226.1Mi ± 2%    230.9Mi ± 3%        ~ (p=0.109 n=10)
HashWithCollision/sha1cd_native-2    81.19Mi ± 1%    99.83Mi ± 0%  +22.96% (p=0.000 n=10)
HashWithCollision/sha1cd_generic-2   69.42Mi ± 1%    69.50Mi ± 0%        ~ (p=0.196 n=10)
HashWithCollision/sha1cd_cgo-2       92.60Mi ± 1%    94.38Mi ± 1%   +1.92% (p=0.004 n=10)
geomean                              114.8Mi         127.0Mi       +10.62%

```