### PR TITLE
Performance improvements for AMD64 and Generic

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,10 @@
+{
+  "enabled": true,
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "pjbgf/entire"
+    }
+  },
+  "telemetry": true
+}

--- a/cgo/fallback_no_cgo.go
+++ b/cgo/fallback_no_cgo.go
@@ -12,7 +12,7 @@ import (
 
 // CalculateDvMask falls back to github.com/pjbgf/sha1cd/ubc implementation
 // due to CGO being disabled at compilation time.
-func CalculateDvMask(W [80]uint32) uint32 {
+func CalculateDvMask(W *[80]uint32) uint32 {
 	return ubc.CalculateDvMask(W)
 }
 

--- a/sha1cd_test.go
+++ b/sha1cd_test.go
@@ -284,7 +284,7 @@ func TestRectifyCompressionState(t *testing.T) {
 		t.Run(fmt.Sprintf("tc#%d", i), func(t *testing.T) {
 			t.Parallel()
 
-			rectifyCompressionState(tc.m1, tc.cs)
+			rectifyCompressionState(&tc.m1, tc.cs)
 
 			if tc.want == nil {
 				if tc.cs != nil {

--- a/sha1cdblock_amd64.go
+++ b/sha1cdblock_amd64.go
@@ -37,9 +37,9 @@ func block(dig *digest, p []byte) {
 		chunk := p[:shared.Chunk]
 
 		blockAMD64(dig.h[:], chunk, m1[:], cs[:])
-		rectifyCompressionState(m1, &cs)
+		rectifyCompressionState(&m1, &cs)
 
-		col := checkCollision(m1, cs, dig.h)
+		col := checkCollision(&m1, &cs, &dig.h)
 		if col {
 			dig.col = true
 

--- a/sha1cdblock_amd64.s
+++ b/sha1cdblock_amd64.s
@@ -11,11 +11,11 @@
 // Reference implementations:
 // 	- https://github.com/golang/go/blob/master/src/crypto/sha1/sha1block_amd64.s
 
+// Reverse the dword order in abcd via PSHUFD then store the 16 bytes in one
+// move, instead of issuing four VPEXTRD's that each go through the store port.
 #define LOADCS(abcd, e, index, target) \
-	VPEXTRD $3, abcd, ((index*20)+0)(target); \
-	VPEXTRD $2, abcd, ((index*20)+4)(target); \
-	VPEXTRD $1, abcd, ((index*20)+8)(target); \
-	VPEXTRD $0, abcd, ((index*20)+12)(target); \
+	VPSHUFD $0x1B, abcd, X8; \
+	VMOVDQU X8, ((index*20)+0)(target); \
 	MOVL e, ((index*20)+16)(target);
 
 #define LOADM1(m1, index, target) \

--- a/sha1cdblock_arm64.go
+++ b/sha1cdblock_arm64.go
@@ -34,8 +34,8 @@ func block(dig *digest, p []byte) {
 
 		blockARM64(dig.h[:], chunk, m1[:], cs[:])
 
-		rectifyCompressionState(m1, &cs)
-		col := checkCollision(m1, cs, dig.h)
+		rectifyCompressionState(&m1, &cs)
+		col := checkCollision(&m1, &cs, &dig.h)
 		if col {
 			dig.col = true
 

--- a/sha1cdblock_generic.go
+++ b/sha1cdblock_generic.go
@@ -127,7 +127,8 @@ func blockGeneric(dig *digest, p []byte) {
 		}
 
 		if hi == 1 {
-			col := checkCollision(m1, cs, [shared.WordBuffers]uint32{h0, h1, h2, h3, h4})
+			h := [shared.WordBuffers]uint32{h0, h1, h2, h3, h4}
+			col := checkCollision(&m1, &cs, &h)
 			if col {
 				dig.col = true
 				hi++
@@ -143,23 +144,23 @@ func blockGeneric(dig *digest, p []byte) {
 
 //go:noinline
 func checkCollision(
-	m1 [shared.Rounds]uint32,
-	cs [shared.PreStepState][shared.WordBuffers]uint32,
-	h [shared.WordBuffers]uint32,
+	m1 *[shared.Rounds]uint32,
+	cs *[shared.PreStepState][shared.WordBuffers]uint32,
+	h *[shared.WordBuffers]uint32,
 ) bool {
 	if mask := ubc.CalculateDvMask(m1); mask != 0 {
 		dvs := ubc.SHA1_dvs()
 
 		for i := 0; dvs[i].DvType != 0; i++ {
 			if (mask & ((uint32)(1) << uint32(dvs[i].MaskB))) != 0 {
-				var csState [shared.WordBuffers]uint32
+				var csState *[shared.WordBuffers]uint32
 				switch dvs[i].TestT {
 				case 58:
-					csState = cs[1]
+					csState = &cs[1]
 				case 65:
-					csState = cs[2]
+					csState = &cs[2]
 				case 0:
-					csState = cs[0]
+					csState = &cs[0]
 				default:
 					panic(fmt.Sprintf("dvs data is trying to use a testT that isn't available: %d", dvs[i].TestT))
 				}
@@ -168,7 +169,7 @@ func checkCollision(
 					dvs[i].TestT, // testT is the step number
 					// m2 is a secondary message created XORing with
 					// ubc's DM prior to the SHA recompression step.
-					m1, dvs[i].Dm,
+					m1, &dvs[i].Dm,
 					csState,
 					h)
 
@@ -182,8 +183,8 @@ func checkCollision(
 }
 
 //go:nosplit
-func hasCollided(step uint32, m1, dm [shared.Rounds]uint32,
-	state [shared.WordBuffers]uint32, h [shared.WordBuffers]uint32) bool {
+func hasCollided(step uint32, m1, dm *[shared.Rounds]uint32,
+	state *[shared.WordBuffers]uint32, h *[shared.WordBuffers]uint32) bool {
 	// Intermediary Hash Value.
 	ihv := [shared.WordBuffers]uint32{}
 
@@ -282,7 +283,7 @@ func hasCollided(step uint32, m1, dm [shared.Rounds]uint32,
 //
 //go:nosplit
 func rectifyCompressionState(
-	m1 [shared.Rounds]uint32,
+	m1 *[shared.Rounds]uint32,
 	cs *[shared.PreStepState][shared.WordBuffers]uint32,
 ) {
 	if cs == nil {

--- a/test/native_test.go
+++ b/test/native_test.go
@@ -22,7 +22,7 @@ func BenchmarkCalculateDvMask(b *testing.B) {
 
 	b.Run("go", func(b *testing.B) {
 		b.ReportAllocs()
-		ubc.CalculateDvMask(data)
+		ubc.CalculateDvMask(&data)
 	})
 	b.Run("cgo", func(b *testing.B) {
 		b.ReportAllocs()
@@ -191,7 +191,7 @@ func TestCalculateDvMask_Shattered1(t *testing.T) {
 		t.Run(fmt.Sprintf("m1[%d]", i), func(t *testing.T) {
 			want := cgo.CalculateDvMask(shattered1M1s[i])
 
-			got := ubc.CalculateDvMask(shattered1M1s[i])
+			got := ubc.CalculateDvMask(&shattered1M1s[i])
 			if want != got {
 				t.Fatalf("[go] dvmask: %d\nwant %d", got, want)
 			}

--- a/ubc/ubc.go
+++ b/ubc/ubc.go
@@ -29,7 +29,10 @@ type DvInfo struct {
 // bitconditions for that DV have been met.
 //
 //go:nosplit
-func CalculateDvMask(W [80]uint32) uint32 {
+func CalculateDvMask(W *[80]uint32) uint32 {
+	if W == nil {
+		return 0
+	}
 	mask := uint32(0xFFFFFFFF)
 	mask &= (((((W[44] ^ W[45]) >> 29) & 1) - 1) | ^(DV_I_48_0_bit | DV_I_51_0_bit | DV_I_52_0_bit | DV_II_45_0_bit | DV_II_46_0_bit | DV_II_50_0_bit | DV_II_51_0_bit))
 	mask &= (((((W[49] ^ W[50]) >> 29) & 1) - 1) | ^(DV_I_46_0_bit | DV_II_45_0_bit | DV_II_50_0_bit | DV_II_51_0_bit | DV_II_55_0_bit | DV_II_56_0_bit))


### PR DESCRIPTION
Performance optimisations:
- Replace four calls to `VPEXTRD` with `VPSHUFD` + `VMOVDQU`.
- Share intermediate values via reference, as opposed to by value.

### Benchstat
```
                                    │         before       │                   after                   │
                                    │        sec/op        │        sec/op         vs base             │
CalculateDvMask/go-24                 0.0000004000n ±  25%   0.0000003500n ± 186%        ~ (p=1.000 n=6)
CalculateDvMask/cgo-24                0.0000008000n ± 313%   0.0000008500n ± 288%        ~ (p=0.617 n=6)
Hash8Bytes/sha1-24                           55.99n ±   4%          56.21n ±   5%        ~ (p=0.699 n=6)
Hash8Bytes/sha1cd_native-24                 102.20n ±   4%          92.41n ±   2%   -9.57% (p=0.002 n=6)
Hash8Bytes/sha1cd_generic-24                 158.8n ±   1%          155.4n ±   3%   -2.17% (p=0.026 n=6)
Hash8Bytes/sha1cd_cgo-24                     587.3n ±  10%          600.8n ±  19%        ~ (p=0.485 n=6)
Hash320Bytes/sha1-24                         170.8n ±   6%          173.0n ±   5%        ~ (p=0.937 n=6)
Hash320Bytes/sha1cd_native-24                484.6n ±  10%          421.0n ±   2%  -13.12% (p=0.002 n=6)
Hash320Bytes/sha1cd_generic-24               886.5n ±  12%          805.8n ±   3%   -9.10% (p=0.002 n=6)
Hash320Bytes/sha1cd_cgo-24                  1087.5n ±   4%          943.7n ±  26%        ~ (p=0.394 n=6)
Hash1K/sha1-24                               433.2n ±   8%          439.1n ±   1%        ~ (p=0.255 n=6)
Hash1K/sha1cd_native-24                      1.282µ ±   2%          1.147µ ±   2%  -10.60% (p=0.002 n=6)
Hash1K/sha1cd_generic-24                     2.365µ ±   3%          2.284µ ±   2%   -3.42% (p=0.004 n=6)
Hash1K/sha1cd_cgo-24                         1.895µ ±  15%          1.648µ ±   9%        ~ (p=0.061 n=6)
Hash8K/sha1-24                               3.148µ ±   1%          3.169µ ±   1%        ~ (p=0.513 n=6)
Hash8K/sha1cd_native-24                      9.497µ ±   2%          8.466µ ±   1%  -10.86% (p=0.002 n=6)
Hash8K/sha1cd_generic-24                     17.38µ ±   0%          16.67µ ±   1%   -4.12% (p=0.002 n=6)
Hash8K/sha1cd_cgo-24                         9.606µ ±   4%          9.718µ ±  17%        ~ (p=0.240 n=6)
HashWithCollision/sha1cd_native-24           1.915µ ±   2%          1.676µ ±   8%  -12.48% (p=0.002 n=6)
HashWithCollision/sha1cd_generic-24          2.625µ ±   2%          2.403µ ±   2%   -8.46% (p=0.002 n=6)
HashWithCollision/sha1cd_cgo-24              1.961µ ±   5%          2.012µ ±  21%        ~ (p=0.258 n=6)
geomean                                      142.4n                 134.8n          -5.29%

                                    │     before      │                after               │
                                    │      B/op       │     B/op      vs base              │
CalculateDvMask/go-24                    0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
CalculateDvMask/cgo-24                   0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1-24                       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1cd_native-24              0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1cd_generic-24             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1cd_cgo-24               2.625Ki ± 0%     2.625Ki ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1-24                     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1cd_native-24            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1cd_generic-24           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1cd_cgo-24             2.625Ki ± 0%     2.625Ki ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1-24                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1cd_native-24                  0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1cd_generic-24                 0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1cd_cgo-24                   2.625Ki ± 0%     2.625Ki ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1-24                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1cd_native-24                  0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1cd_generic-24                 0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1cd_cgo-24                   2.625Ki ± 0%     2.625Ki ± 0%       ~ (p=1.000 n=6) ¹
HashWithCollision/sha1cd_native-24       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
HashWithCollision/sha1cd_generic-24      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
HashWithCollision/sha1cd_cgo-24        2.625Ki ± 0%     2.625Ki ± 0%       ~ (p=1.000 n=6) ¹
geomean                                             ²                 +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                    │     before      │                after              │
                                    │    allocs/op    │ allocs/op   vs base               │
CalculateDvMask/go-24                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
CalculateDvMask/cgo-24                   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1-24                       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1cd_native-24              0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1cd_generic-24             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8Bytes/sha1cd_cgo-24                 1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1-24                     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1cd_native-24            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1cd_generic-24           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash320Bytes/sha1cd_cgo-24               1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1-24                           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1cd_native-24                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1cd_generic-24                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash1K/sha1cd_cgo-24                     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1-24                           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1cd_native-24                  0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1cd_generic-24                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Hash8K/sha1cd_cgo-24                     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
HashWithCollision/sha1cd_native-24       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
HashWithCollision/sha1cd_generic-24      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
HashWithCollision/sha1cd_cgo-24          1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                             ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                    │     before    │                after               │
                                    │       B/s       │      B/s       vs base               │
Hash8Bytes/sha1-24                      136.3Mi ±  4%   135.7Mi ±  5%        ~ (p=0.615 n=6)
Hash8Bytes/sha1cd_native-24             74.65Mi ±  3%   82.55Mi ±  2%  +10.59% (p=0.002 n=6)
Hash8Bytes/sha1cd_generic-24            48.04Mi ±  1%   49.11Mi ±  2%   +2.24% (p=0.026 n=6)
Hash8Bytes/sha1cd_cgo-24                12.99Mi ±  9%   12.70Mi ± 16%        ~ (p=0.485 n=6)
Hash320Bytes/sha1-24                    1.745Gi ±  6%   1.722Gi ±  4%        ~ (p=0.937 n=6)
Hash320Bytes/sha1cd_native-24           629.7Mi ±  9%   724.8Mi ±  2%  +15.10% (p=0.002 n=6)
Hash320Bytes/sha1cd_generic-24          344.3Mi ± 11%   378.7Mi ±  3%   +9.98% (p=0.002 n=6)
Hash320Bytes/sha1cd_cgo-24              280.5Mi ±  4%   326.2Mi ± 21%        ~ (p=0.394 n=6)
Hash1K/sha1-24                          2.201Gi ±  8%   2.172Gi ±  2%        ~ (p=0.240 n=6)
Hash1K/sha1cd_native-24                 761.4Mi ±  1%   851.9Mi ±  2%  +11.87% (p=0.002 n=6)
Hash1K/sha1cd_generic-24                412.9Mi ±  3%   427.6Mi ±  2%   +3.56% (p=0.004 n=6)
Hash1K/sha1cd_cgo-24                    516.2Mi ± 14%   593.2Mi ±  8%        ~ (p=0.065 n=6)
Hash8K/sha1-24                          2.424Gi ±  1%   2.408Gi ±  1%        ~ (p=0.589 n=6)
Hash8K/sha1cd_native-24                 822.7Mi ±  2%   922.8Mi ±  1%  +12.17% (p=0.002 n=6)
Hash8K/sha1cd_generic-24                449.4Mi ±  0%   468.7Mi ±  2%   +4.30% (p=0.002 n=6)
Hash8K/sha1cd_cgo-24                    813.3Mi ±  4%   803.9Mi ± 15%        ~ (p=0.240 n=6)
HashWithCollision/sha1cd_native-24      318.8Mi ±  2%   364.3Mi ±  7%  +14.27% (p=0.002 n=6)
HashWithCollision/sha1cd_generic-24     232.6Mi ±  2%   254.0Mi ±  2%   +9.22% (p=0.002 n=6)
HashWithCollision/sha1cd_cgo-24         311.3Mi ±  5%   303.3Mi ± 17%        ~ (p=0.310 n=6)
geomean                                 363.0Mi         384.2Mi         +5.83%
```