### PR TITLE
Remove self-registration via `crypto.RegisterHash`

### DIFF
--- a/cgo/sha1.go
+++ b/cgo/sha1.go
@@ -5,7 +5,6 @@ package cgo
 import "C"
 
 import (
-	"crypto"
 	"hash"
 	"unsafe"
 )
@@ -14,10 +13,6 @@ const (
 	Size      = 20
 	BlockSize = 64
 )
-
-func init() {
-	crypto.RegisterHash(crypto.SHA1, New)
-}
 
 func New() hash.Hash {
 	var d digest

--- a/sha1cd.go
+++ b/sha1cd.go
@@ -12,17 +12,12 @@ package sha1cd
 // Original: https://github.com/golang/go/blob/master/src/crypto/sha1/sha1.go
 
 import (
-	"crypto"
 	"encoding/binary"
 	"errors"
 	"hash"
 
 	shared "github.com/pjbgf/sha1cd/internal"
 )
-
-func init() {
-	crypto.RegisterHash(crypto.SHA1, New)
-}
 
 // The size of a SHA-1 checksum in bytes.
 const Size = shared.Size


### PR DESCRIPTION
This library is primarily used by `go-git`, which does not rely on the `crypto` package's registration mechanism to register its implementation. Therefore, it will no longer automatically self-register itself.